### PR TITLE
Version 1.0.4

### DIFF
--- a/js/queryLight.js
+++ b/js/queryLight.js
@@ -5,7 +5,7 @@
  *
  * Author: Alexandr Shamanin (@slpAkkie)
  * Version: 1.0.3.1
- * File Version: 1.0.9
+ * File Version: 1.0.10
 */
 
 
@@ -39,7 +39,11 @@ function qL( input, parent = null ) {
     removeClass( classString ) { this.each( el => el.classList.remove( classString ) ); return this },
     toggleClass( classString ) { this.each( el => _( el ).hasClass( classString ) ? _( el ).removeClass( classString ) : _( el ).addClass( classString ) ) },
     hasClass( classString ) { return this.__elements.some( el => el.classList.contains( classString ) ) },
-    on( eventName, callback ) { this.each( el => el.addEventListener( eventName, callback ) ); return this },
+    on( eventName, callback ) {
+      this.each( function ( el ) { el.addEventListener( eventName, callback.bind( _( this ) ) ) } );
+
+      return this
+    },
     each( callback ) { this.__elements.forEach( el => callback.call( _( el ), _( el ) ) ); return this },
     insertBefore( sibling ) {
       this.parent.insertBefore( sibling, this.get() );
@@ -67,6 +71,11 @@ function qL( input, parent = null ) {
 
         return child
       }
+    },
+    clear() {
+      this.each( el => el.innerHTML = '' );
+
+      return this
     },
     get( index = null, as_qL = false ) { let el = ( index === null ) ? this.__elements[ 0 ] : this.__elements[ index ]; return as_qL ? qL( el ) : el },
 

--- a/js/queryLight.js
+++ b/js/queryLight.js
@@ -5,7 +5,7 @@
  *
  * Author: Alexandr Shamanin (@slpAkkie)
  * Version: 1.0.3.1
- * File Version: 1.0.8
+ * File Version: 1.0.9
 */
 
 
@@ -54,7 +54,7 @@ function qL( input, parent = null ) {
 
       return sibling
     },
-    insertLast( child, multiInsert = false ) {
+    insert( child, multiInsert = false ) {
       !child.qL && ( child = _( child ) );
 
       if ( multiInsert ) {

--- a/js/queryLight.js
+++ b/js/queryLight.js
@@ -5,7 +5,7 @@
  *
  * Author: Alexandr Shamanin (@slpAkkie)
  * Version: 1.0.3.1
- * File Version: 1.0.6
+ * File Version: 1.0.7
 */
 
 
@@ -54,12 +54,19 @@ function qL( input, parent = null ) {
 
       return sibling
     },
-    insertLast( child ) {
-      child.qL
-        ? this.each( el => child.each( ch => el.insertLast( ch.get() ) ) )
-        : this.each( el => el.appendChild( child.cloneNode( true ) ) );
+    insertLast( child, multiInsert = false ) {
+      !child.qL && ( child = _( child ) );
 
-      return this
+      if ( multiInsert ) {
+        this.each( el => child.each( ch => el.appendChild( ch.get().cloneNode( true ) ) ) );
+
+        return this
+      } else {
+        this.__aloneRequire();
+        child.each( ch => this.appendChild( ch.get() ) );
+
+        return child
+      }
     },
     get( index = null, as_qL = false ) { let el = ( index === null ) ? this.elements[ 0 ] : this.elements[ index ]; return as_qL ? qL( el ) : el },
 

--- a/js/queryLight.js
+++ b/js/queryLight.js
@@ -5,7 +5,7 @@
  *
  * Author: Alexandr Shamanin (@slpAkkie)
  * Version: 1.0.3.1
- * File Version: 1.0.11
+ * File Version: 1.0.12
 */
 
 
@@ -75,6 +75,20 @@ function qL( input, parent = null ) {
       } else {
         this.__aloneRequire();
         child.each( ch => this.appendChild( ch.get() ) );
+
+        return child
+      }
+    },
+    insertFirst( child, multiInsert = false ) {
+      !child.qL && ( child = _( child ) );
+
+      if ( multiInsert ) {
+        this.each( el => child.each( ch => _( el.firstElementChild )?.insertBefore( ch.get().cloneNode( true ) ) || el.insert( ch ) ) );
+
+        return this
+      } else {
+        this.__aloneRequire();
+        child.each( ch => _( this.firstElementChild )?.insertBefore( ch.get() ) || this.insert( ch ) );
 
         return child
       }

--- a/js/queryLight.js
+++ b/js/queryLight.js
@@ -5,7 +5,7 @@
  *
  * Author: Alexandr Shamanin (@slpAkkie)
  * Version: 1.0.3.1
- * File Version: 1.0.10
+ * File Version: 1.0.11
 */
 
 
@@ -46,7 +46,14 @@ function qL( input, parent = null ) {
     },
     each( callback ) { this.__elements.forEach( el => callback.call( _( el ), _( el ) ) ); return this },
     insertBefore( sibling ) {
-      this.parent.insertBefore( sibling, this.get() );
+      this.__aloneRequire();
+
+      if ( sibling.qL ) {
+        let parent = this.parent().get();
+
+        sibling.each( ch => parent.insertBefore( ch.get(), this.get() ) );
+      } else
+        this.parent().get().insertBefore( sibling, this.get() );
 
       return sibling
     },
@@ -72,6 +79,7 @@ function qL( input, parent = null ) {
         return child
       }
     },
+    replace( newElement ) { this.replaceWith( newElement.qL ? newElement.get() : newElement ); return newElement },
     clear() {
       this.each( el => el.innerHTML = '' );
 
@@ -88,8 +96,20 @@ function qL( input, parent = null ) {
       return value || this.innerText;
     },
     len() { return this.__elements.length },
-    parent() { return this.parentElement },
-    prev() { return this.previousElementSibling },
+    parent( selector = null ) {
+      if ( !selector ) return _( this.parentElement );
+
+      this.__aloneRequire();
+      let parent = this.parent();
+      while ( !parent.matches( selector ) ) {
+        if ( parent.matches( ':root' ) ) return null;
+
+        parent = parent.parent();
+      }
+
+      return parent;
+    },
+    prev() { return _( this.previousElementSibling ) },
     elements() {
       this.__aloneRequire();
 
@@ -121,7 +141,11 @@ function qL( input, parent = null ) {
 
     /** Служебные функции */
     __aloneRequire() { if ( this.len() > 1 ) throw new Error( `Коллекция состоит из ${this.len()} элементов. Я не понимаю для какого элемента вы хотите получить значение` ); return true },
-    __push( element ) { element instanceof Element && this.__elements.push( element ); return this },
+    __push( element ) {
+      ( element instanceof Element || element.qL )
+        && this.__elements.push( element.qL ? element.get() : element );
+      return this
+    },
   } );
 
 

--- a/js/queryLight.js
+++ b/js/queryLight.js
@@ -4,7 +4,7 @@
  * Скрипты предоставлены для queryLight (ql)
  *
  * Author: Alexandr Shamanin (@slpAkkie)
- * Version: 1.0.3.1
+ * Version: 1.0.4
  * File Version: 1.0.12
 */
 


### PR DESCRIPTION
- *Added new functions:*
**prev**: Find previous element
**elements**: For HTML Forms to take only its fields
**formData**: Take an object or array of objects with name-value pairs or null if no fields
**clear**: Clear all innerHTML
**insertFirst**: Working similar as `insert` but append sibling to the top

- *Fix:*
**insertBefore**: Sibling may be a qL wrapper
**parent**: Now you can find parent with selector
**prev**: Returns qL wrapper
**__push**: element may be a qL wrapper

- *Others:*
Renamed `insertLast` to `insert`
Now in the `on` function reference `this` will have a `qL wrapper`