### PR TITLE
Version 1.0.5

### DIFF
--- a/js/queryLight.js
+++ b/js/queryLight.js
@@ -5,7 +5,7 @@
  *
  * Author: Alexandr Shamanin (@slpAkkie)
  * Version: 1.0.4
- * File Version: 1.0.13
+ * File Version: 1.0.14
 */
 
 
@@ -156,6 +156,20 @@ function qL( input, parent = null ) {
       if ( withGETQuery && this.__aloneRequire() ) return { GETQuery: GETQueryFrom( formsData[ 0 ] ), formData: formsData[ 0 ] };
       return formsData.length > 1 ? formsData : ( formsData.length === 1 ? formsData[ 0 ] : null );
     },
+    equalTo( element ) {
+      this.__aloneRequire();
+
+      return this.get() === ( element.ql ? element.get() : element );
+    },
+    inCollection( element ) {
+      inCollection = false;
+
+      this.each( el => {
+        if ( el.equalTo( element ) ) inCollection = true;
+      } );
+
+      return inCollection;
+    },
 
 
 
@@ -163,6 +177,7 @@ function qL( input, parent = null ) {
     __aloneRequire() { if ( this.len() > 1 ) throw new Error( `Коллекция состоит из ${this.len()} элементов. Я не понимаю для какого элемента вы хотите получить значение` ); return true },
     __push( element ) {
       ( element instanceof Element || element.qL )
+        && !this.inCollection( element )
         && this.__elements.push( element.qL ? element.get() : element );
       return this
     },

--- a/js/queryLight.js
+++ b/js/queryLight.js
@@ -4,8 +4,8 @@
  * Скрипты предоставлены для queryLight (ql)
  *
  * Author: Alexandr Shamanin (@slpAkkie)
- * Version: 1.0.4
- * File Version: 1.0.14
+ * Version: 1.0.5
+ * File Version: 1.0.15
 */
 
 
@@ -39,9 +39,18 @@ function qL( input, parent = null ) {
     removeClass( classString ) { this.each( el => el.classList.remove( classString ) ); return this },
     toggleClass( classString ) { this.each( el => _( el ).hasClass( classString ) ? _( el ).removeClass( classString ) : _( el ).addClass( classString ) ) },
     hasClass( classString ) { return this.__elements.some( el => el.classList.contains( classString ) ) },
-    on( eventName, callback ) {
-      this.each( function ( el ) { el.addEventListener( eventName, callback.bind( _( this ) ) ) } );
-
+    on( eventName, callback, alias = null ) {
+      this.each( function ( el ) {
+        let handler = alias ? ( el[ `Handler_${alias}` ] = callback.bind( _( this ) ) ) : callback.bind( _( this ) );
+        el.addEventListener( eventName, handler );
+      } );
+      return this
+    },
+    removeOn( eventName, alias ) {
+      this.each( function ( el ) {
+        let handler = el.get()[ `Handler_${alias}` ] || null;
+        if ( handler !== null ) el.removeEventListener( eventName, handler );
+      } );
       return this
     },
     each( callback ) { this.__elements.forEach( ( el, i ) => callback.call( _( el ), _( el ), i ) ); return this },

--- a/js/queryLight.js
+++ b/js/queryLight.js
@@ -5,7 +5,7 @@
  *
  * Author: Alexandr Shamanin (@slpAkkie)
  * Version: 1.0.4
- * File Version: 1.0.12
+ * File Version: 1.0.13
 */
 
 
@@ -44,7 +44,7 @@ function qL( input, parent = null ) {
 
       return this
     },
-    each( callback ) { this.__elements.forEach( el => callback.call( _( el ), _( el ) ) ); return this },
+    each( callback ) { this.__elements.forEach( ( el, i ) => callback.call( _( el ), _( el ), i ) ); return this },
     insertBefore( sibling ) {
       this.__aloneRequire();
 
@@ -58,10 +58,10 @@ function qL( input, parent = null ) {
       return sibling
     },
     insertAfter( sibling ) {
-      let nextSibling = this.nextSibling;
+      let nextSibling = _( this.nextElementSibling );
       nextSibling
-        ? this.parent.insertBefore( sibling, this.nextSibling )
-        : this.parent.appendChild( sibling );
+        ? nextSibling.insertBefore( sibling )
+        : this.parent().insert( sibling );
 
       return sibling
     },
@@ -109,6 +109,11 @@ function qL( input, parent = null ) {
 
       return value || this.innerText;
     },
+    val( val = null ) {
+      val && ( this.value = val );
+
+      return this.value;
+    },
     len() { return this.__elements.length },
     parent( selector = null ) {
       if ( !selector ) return _( this.parentElement );
@@ -124,6 +129,7 @@ function qL( input, parent = null ) {
       return parent;
     },
     prev() { return _( this.previousElementSibling ) },
+    next() { return _( this.nextElementSibling ) },
     elements() {
       this.__aloneRequire();
 
@@ -165,7 +171,7 @@ function qL( input, parent = null ) {
 
 
   /** Проверка на входные параметры */
-  if ( parent && parent.qL && parent.__aloneRequire() ) parent = parent.get();
+  if ( parent && parent.qL && parent.__aloneRequire() ) parent = parent.get()
   else if ( !( parent instanceof Element ) ) {
     if ( parent !== null ) throw new Error( 'Родительский элемент не был DOM элементом. Если вы использовали элемент, взятый с помощью qL убедитесь что получили конкретный DOM элемент' );
     parent = document;
@@ -173,8 +179,8 @@ function qL( input, parent = null ) {
 
   if ( input && input.qL === true ) return input;
 
-  if ( typeof input === 'string' ) queryLight.__elements = Array.from( parent.querySelectorAll( input ) );
-  else if ( input instanceof Element || input instanceof Window || input instanceof Document ) queryLight.__elements = [ input ];
+  if ( typeof input === 'string' ) queryLight.__elements = Array.from( parent.querySelectorAll( input ) )
+  else if ( input instanceof Element || input instanceof Window || input instanceof Document ) queryLight.__elements = [ input ]
   else return null;
   if ( queryLight.len() === 0 ) return null;
 
@@ -188,7 +194,7 @@ function qL( input, parent = null ) {
         target = target.get();
         let gotten = Reflect.get( target, prop );
 
-        if ( typeof gotten === 'function' ) return gotten.bind( target );
+        if ( typeof gotten === 'function' ) return gotten.bind( target )
         else return gotten;
       }
 


### PR DESCRIPTION
# Version 1.0.5

- *Added*
**next**: Returns qL wrapper for element which next for `this`
**val**: Returns or sets a value for the input (or other Element of course)
**equalTo**: Returns `true` or `false`
**inCollection**: Returns `true` or `false`
**removeOn**: Function to remove handler from element by its alias

- *Updated*
**each**: callback function will be able to get an index as second parameter
**insertAfter**: nextSibling now have a qL wrapper
**on**: Add alias in arguments to save handler and name it

- *Fix*
**__push**:  Fix duplicate in some cases when push new element into qL wrapper